### PR TITLE
Added Package Settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,4 +6,4 @@ For example: `.foo` will now expand to `<div className={style.foo}></div>` inste
 
 ## TODO
 
-- [ ] Allow the `style` variable name to be customized via Atom's preferences.
+- [x] Allow the `style` variable name to be customized via Atom's preferences.

--- a/lib/emmet-jsx-css-modules.js
+++ b/lib/emmet-jsx-css-modules.js
@@ -2,22 +2,29 @@
 
 export default {
 
-  activate(state) {
-    if (atom.packages.isPackageLoaded('emmet')) {
-      const pkgDir  = path.resolve(atom.packages.resolvePackagePath('emmet'), 'node_modules', 'emmet', 'lib')
-      const emmet   = require(path.join(pkgDir, 'emmet'))
-      const filters = require(path.join(pkgDir, 'filter', 'main'))
+    activate(state) {
+        if (atom.packages.isPackageLoaded('emmet')) {
+            const pkgDir  = path.resolve(atom.packages.resolvePackagePath('emmet'), 'node_modules', 'emmet', 'lib')
+            const emmet   = require(path.join(pkgDir, 'emmet'))
+            const filters = require(path.join(pkgDir, 'filter', 'main'))
 
-      filters.add('jsx-css-modules', (tree) => {
-        tree.children.forEach((item) => {
-          item.start = item.start.replace(/className="(.*)"/, "className={style.$1}")
-        })
-      })
+            filters.add('jsx-css-modules', (tree) => {
+                tree.children.forEach((item) => {
+                    item.start = item.start.replace(/className="(.*)"/, "className={" + atom.config.get('emmet-jsx-css-modules.styleVariableName') + ".$1}")
+                })
+            })
 
-      // Apply jsx-css-modules after html so we can use a simple string replacement
-      // and not have to mess with how the the html filter wraps attribute values with
-      // quotation marks rather than curly brace pairs
-      emmet.loadSnippets({"jsx": { "filters": "jsx, html, jsx-css-modules" }})
+            // Apply jsx-css-modules after html so we can use a simple string replacement
+            // and not have to mess with how the the html filter wraps attribute values with
+            // quotation marks rather than curly brace pairs
+            emmet.loadSnippets({"jsx": { "filters": "jsx, html, jsx-css-modules" }})
+        }
+    },
+
+    config: {
+        styleVariableName: {
+            type: 'string',
+            default: 'style'
+        }
     }
-  }
 }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "emmet-jsx-css-modules",
   "main": "./lib/emmet-jsx-css-modules",
   "author": "Jason L Perry <jasper@ambethia.com>",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Extends Emmet's JSX expansions to use CSS modules.",
   "keywords": [
     "emmet",
@@ -13,5 +13,8 @@
   "license": "MIT",
   "engines": {
     "atom": ">=1.0.0 <2.0.0"
-  }
+  },
+  "contributors": [
+    "Sabin Marcu <sabinmarcu@gmail.com>"
+  ]
 }


### PR DESCRIPTION
## Reason for PR

I saw the Todo item, and decided to contribute :smiley:
PR adds a variable to the package's settings, so you can customize the containing object for classes.
### Result

![screenshot from 2016-08-04 13-55-18](https://cloud.githubusercontent.com/assets/333327/17399565/76e72d82-5a4b-11e6-9e95-cc6f853541dd.png)

And, as expected, expanding the following: 
![screenshot from 2016-08-04 13-55-33](https://cloud.githubusercontent.com/assets/333327/17399564/76e7294a-5a4b-11e6-9a20-6e0d3ad76070.png)

Will generate the following: 
![screenshot from 2016-08-04 13-56-00](https://cloud.githubusercontent.com/assets/333327/17399566/76e95abc-5a4b-11e6-9a81-55f62e6550ba.png)
#### Should already be ready for a push (version bumped, and all).

Hope you don't mind the change in tabbing. I can change it back to 2 spaces if you prefer.
